### PR TITLE
Bug/60: Request destructuring fix for Auth controller

### DIFF
--- a/src/api/auth/auth.controller.js
+++ b/src/api/auth/auth.controller.js
@@ -7,13 +7,13 @@ class AuthController {
     return new AuthController(service)
   }
 
-  signin({ payload = {} }) {
-    const { email, password } = payload
+  signin({ payload }) {
+    const { email, password } = payload || {}
     return this.authService.signin(email, password)
   }
 
-  signup({ payload = {} }) {
-    const { email, password } = payload
+  signup({ payload }) {
+    const { email, password } = payload || {}
     return this.authService.signup(email, password)
   }
 }


### PR DESCRIPTION
According to the [Default Parameters documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters):

Passing undefined vs. other falsy values:
Even if the argument is set explicitly to undefined (though **not null or other falsy values**), the value of the argument is still the default.

Here, payload could be equal to `null` at the moment of function invocation, causing the following error:
```
TypeError: Uncaught error: Cannot match against 'undefined' or 'null'.
```